### PR TITLE
feat: :sparkles: differentiate title from sanitized title

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ The frontmatter template can be turned on and off. If you want to revert to the 
 The template exposes the following variables (they can be used for both the header and frontmatter):
 
 - ```id```: Document id,
-- ```title```: Sanitized title,
+- ```title```: Title,
+- ```sanitized_title```: Sanitized title (Equals the filename, good for use as an alias)
 - ```author```: Author (raw),
 - ```authorStr```: Author (formatted, as Wiki Links ```[[Author Name]]```),
 - ```category```: Document category,
@@ -123,6 +124,7 @@ The following would print both document and all highlight tags, rolled-up:
 id: {{ id }}
 updated: {{ updated }}
 title: "{{ title }}"
+alias: "{{ sanitized_title }}"
 author: "{{ author }}"
 highlights: {{ num_highlights }}
 last_highlight_at: {{ last_highlight_at }}

--- a/main.ts
+++ b/main.ts
@@ -52,7 +52,7 @@ Updated: {{ updated }}
 ![]( {{ cover_image_url }})
 
 # About
-Title: [[{{ title }}]]
+Title: [[{{ sanitized_title }}]]
 Authors: {{ authorStr }}
 Category: #{{ category }}
 {%- if tags %}
@@ -264,7 +264,7 @@ export default class ReadwiseMirror extends Plugin {
       const filteredHighlights = this.filterHighlights(highlights);
 
       if (filteredHighlights.length === 0) {
-        console.log(`Readwise: No highlights found for '${sanitizedTitle}'`);
+        console.log(`Readwise: No highlights found for '${title}' (${highlights_url})`);
       } else {
         const formattedHighlights = this.sortHighlights(filteredHighlights)
           .map((highlight: Highlight) => this.formatHighlight(highlight, book))
@@ -286,7 +286,8 @@ export default class ReadwiseMirror extends Plugin {
 
         const metadata = {
           id: id,
-          title: sanitizedTitle,
+          title: title,
+          sanitized_title: sanitizedTitle,
           author: author,
           authorStr: authorStr,
           category: category,


### PR DESCRIPTION
While the sanitized title is necessary for file names, one might actually want to use the *real* title in the contents. This change implements this.

The old default header template uses `title` which will create invalid links for titles with special characters. Users are advised to update their templates before running a sync.